### PR TITLE
Add Auth component for route protection

### DIFF
--- a/client/src/components/Auth.jsx
+++ b/client/src/components/Auth.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Redirect, Route } from 'react-router-dom';
+
+// Higher-order component for protecting routes
+const Auth = ({ component: Component, ...rest }) => {
+    const token = localStorage.getItem('token');
+    return (
+        <Route
+            {...rest}
+            render={props =>
+                token ? <Component {...props} /> : <Redirect to="/login" />
+            }
+        />
+    );
+};
+
+export default Auth;


### PR DESCRIPTION
This PR introduces the `Auth` component, which is a higher-order component used to protect routes by checking for a valid token in local storage. If the token is not present, the user is redirected to the login page.
